### PR TITLE
Add snippet for .log() in angular javascript files

### DIFF
--- a/Snippets/$log.tmSnippet
+++ b/Snippets/$log.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+        <string>\$log.log(${1});</string>
+	<key>name</key>
+	<string>$log</string>
+	<key>scope</key>
+	<string>source.js</string>
+	<key>tabTrigger</key>
+	<string>log</string>
+	<key>uuid</key>
+	<string>44333850-B1C4-11E2-9E96-0800200C9A66</string>
+</dict>
+</plist>


### PR DESCRIPTION
During development I use $log.log() a lot for testing. This commit provides a snippet for $log.log. 
Please let me know if you need any changes to this commit.
